### PR TITLE
feat(trading): use 2 dps for formatting

### DIFF
--- a/apps/trading/components/asset-option/asset-option.tsx
+++ b/apps/trading/components/asset-option/asset-option.tsx
@@ -3,9 +3,9 @@ import { type AssetERC20 } from '@vegaprotocol/assets';
 import { Emblem } from '@vegaprotocol/emblem';
 import { truncateMiddle } from '@vegaprotocol/ui-toolkit';
 import { addDecimalsFormatNumber, isAssetNative } from '@vegaprotocol/utils';
-import { getErc20Abi } from 'apps/trading/lib/utils/get-erc20-abi';
+import { getErc20Abi } from '../../lib/utils/get-erc20-abi';
 import { useAccount, useBalance, useReadContracts } from 'wagmi';
-import { DEFAULT_DISPLAY_DPS } from '../deposit-container/contants';
+import { DEFAULT_DISPLAY_DPS } from '../../lib/constants';
 
 export const AssetOption = ({
   asset,

--- a/apps/trading/components/asset-option/asset-option.tsx
+++ b/apps/trading/components/asset-option/asset-option.tsx
@@ -5,6 +5,7 @@ import { truncateMiddle } from '@vegaprotocol/ui-toolkit';
 import { addDecimalsFormatNumber, isAssetNative } from '@vegaprotocol/utils';
 import { getErc20Abi } from 'apps/trading/lib/utils/get-erc20-abi';
 import { useAccount, useBalance, useReadContracts } from 'wagmi';
+import { DEFAULT_DISPLAY_DPS } from '../deposit-container/contants';
 
 export const AssetOption = ({
   asset,
@@ -52,7 +53,15 @@ const NativeTokenBalance = (props: AssetBalanceProps) => {
 
   if (!data) return null;
 
-  return <>{addDecimalsFormatNumber(data.value.toString(), data.decimals)}</>;
+  return (
+    <>
+      {addDecimalsFormatNumber(
+        data.value.toString(),
+        data.decimals,
+        DEFAULT_DISPLAY_DPS
+      )}
+    </>
+  );
 };
 
 const TokenBalance = (props: AssetBalanceProps) => {
@@ -85,5 +94,9 @@ const TokenBalance = (props: AssetBalanceProps) => {
 
   if (!value || !decimals) return null;
 
-  return <>{addDecimalsFormatNumber(value.toString(), decimals)}</>;
+  return (
+    <>
+      {addDecimalsFormatNumber(value.toString(), decimals, DEFAULT_DISPLAY_DPS)}
+    </>
+  );
 };

--- a/apps/trading/components/deposit-container/contants.ts
+++ b/apps/trading/components/deposit-container/contants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_DISPLAY_DPS = 2;

--- a/apps/trading/components/deposit-container/contants.ts
+++ b/apps/trading/components/deposit-container/contants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_DISPLAY_DPS = 2;

--- a/apps/trading/components/deposit-container/feedback-dialog.tsx
+++ b/apps/trading/components/deposit-container/feedback-dialog.tsx
@@ -15,7 +15,7 @@ import {
   DefaultBadge,
   PendingBadge,
 } from '../transaction-dialog/transaction-badge';
-import { DEFAULT_DISPLAY_DPS } from './contants';
+import { DEFAULT_DISPLAY_DPS } from '../../lib/constants';
 
 type FeedbackDialogProps = {
   data?: TxDeposit;

--- a/apps/trading/components/deposit-container/feedback-dialog.tsx
+++ b/apps/trading/components/deposit-container/feedback-dialog.tsx
@@ -15,6 +15,7 @@ import {
   DefaultBadge,
   PendingBadge,
 } from '../transaction-dialog/transaction-badge';
+import { DEFAULT_DISPLAY_DPS } from './contants';
 
 type FeedbackDialogProps = {
   data?: TxDeposit;
@@ -45,7 +46,11 @@ const Content = (props: { tx: TxDeposit }) => {
           {t('Deposit')} <br />
           {data && data.asset && (
             <span className="text-surface-1-fg text-2xl">
-              {addDecimalsFormatNumber(data.amount, data.asset.decimals)}{' '}
+              {addDecimalsFormatNumber(
+                data.amount,
+                data.asset.decimals,
+                DEFAULT_DISPLAY_DPS
+              )}{' '}
               {data.asset.symbol}
             </span>
           )}

--- a/apps/trading/components/deposit-container/fields/to-asset-targeted.tsx
+++ b/apps/trading/components/deposit-container/fields/to-asset-targeted.tsx
@@ -2,6 +2,8 @@ import { FormGroup } from '@vegaprotocol/ui-toolkit';
 import { AssetOption } from '../../asset-option';
 import { type AssetERC20 } from '@vegaprotocol/assets';
 import { useT } from '../../../lib/use-t';
+import { formatNumber } from '@vegaprotocol/utils';
+import { DEFAULT_DISPLAY_DPS } from '../../../lib/constants';
 
 export const ToAssetTargeted = (props: {
   toAsset: AssetERC20;
@@ -10,7 +12,10 @@ export const ToAssetTargeted = (props: {
   const t = useT();
   return (
     <FormGroup label={t('Asset')} labelFor="asset">
-      <AssetOption asset={props.toAsset} balance={props.balance} />
+      <AssetOption
+        asset={props.toAsset}
+        balance={formatNumber(props.balance, DEFAULT_DISPLAY_DPS)}
+      />
     </FormGroup>
   );
 };

--- a/apps/trading/components/deposit-container/fields/to-asset.tsx
+++ b/apps/trading/components/deposit-container/fields/to-asset.tsx
@@ -22,7 +22,7 @@ import { type QueryKey } from '@tanstack/react-query';
 import { type RouteResponse } from '@0xsquid/sdk/dist/types';
 import { addDecimalsFormatNumber } from '@vegaprotocol/utils';
 import { TokenOption } from '../token-option';
-import { DEFAULT_DISPLAY_DPS } from '../contants';
+import { DEFAULT_DISPLAY_DPS } from '../../../lib/constants';
 
 export function ToAsset(props: {
   control: Control<FormFields>;

--- a/apps/trading/components/deposit-container/fields/to-asset.tsx
+++ b/apps/trading/components/deposit-container/fields/to-asset.tsx
@@ -22,6 +22,7 @@ import { type QueryKey } from '@tanstack/react-query';
 import { type RouteResponse } from '@0xsquid/sdk/dist/types';
 import { addDecimalsFormatNumber } from '@vegaprotocol/utils';
 import { TokenOption } from '../token-option';
+import { DEFAULT_DISPLAY_DPS } from '../contants';
 
 export function ToAsset(props: {
   control: Control<FormFields>;
@@ -56,7 +57,8 @@ export function ToAsset(props: {
                         <>
                           {addDecimalsFormatNumber(
                             estimate.toAmount,
-                            token.decimals
+                            token.decimals,
+                            DEFAULT_DISPLAY_DPS
                           )}
                         </>
                       }

--- a/apps/trading/components/withdraw-container/withdraw-container.tsx
+++ b/apps/trading/components/withdraw-container/withdraw-container.tsx
@@ -47,7 +47,7 @@ import { AccountType } from '@vegaprotocol/types';
 import { BRIDGE_ABI } from '@vegaprotocol/smart-contracts';
 
 import { useT } from '../../lib/use-t';
-import { APP_TOKEN_ID } from '../../lib/constants';
+import { APP_TOKEN_ID, DEFAULT_DISPLAY_DPS } from '../../lib/constants';
 
 import {
   FormSecondaryActionButton,
@@ -297,7 +297,8 @@ const WithdrawForm = ({
                         asset={asset}
                         balance={addDecimalsFormatNumber(
                           a.balance,
-                          asset.decimals
+                          asset.decimals,
+                          DEFAULT_DISPLAY_DPS
                         )}
                       />
                     </TradingRichSelectOption>

--- a/apps/trading/lib/constants.ts
+++ b/apps/trading/lib/constants.ts
@@ -15,3 +15,5 @@ export const ONBOARDING_TARGET_ASSET = APP_TOKEN_ID;
 // be done if the swap was not successfull
 export const SQUID_RECEIVER_ADDRESS =
   '0xE7477a9aDb9BA0d00Af8f4d8e5E53A532C650ffa' as Address;
+
+export const DEFAULT_DISPLAY_DPS = 2;

--- a/libs/accounts/src/lib/transfer-form.tsx
+++ b/libs/accounts/src/lib/transfer-form.tsx
@@ -7,6 +7,7 @@ import {
   toBigNum,
   removeDecimal,
   addDecimalsFormatNumber,
+  formatNumber,
 } from '@vegaprotocol/utils';
 import { useT } from './use-t';
 import {
@@ -31,6 +32,8 @@ import { AccountType, AccountTypeMapping } from '@vegaprotocol/types';
 import { useTransferFeeQuery } from './__generated__/TransferFee';
 import { normalizeTransfer } from './utils';
 import { Emblem } from '@vegaprotocol/emblem';
+
+const DEFAULT_DISPLAY_DPS = 2;
 
 interface FormFields {
   toVegaKey: string;
@@ -607,7 +610,9 @@ const AssetOption = ({
             : asset.source.__typename}
         </div>
       </div>
-      <div className="ml-auto text-sm">{asset.balance}</div>
+      <div className="ml-auto text-sm">
+        {formatNumber(asset.balance, DEFAULT_DISPLAY_DPS)}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
# Related issues 🔗

Closes #34 

# Description ℹ️

Hardcodes 2 dps for formatting values when depositing, withdrawing or transfering
